### PR TITLE
Improve map selection visibility and destination indicator (CampusMap)

### DIFF
--- a/frontend/conuwalks/src/components/CampusMap.tsx
+++ b/frontend/conuwalks/src/components/CampusMap.tsx
@@ -754,8 +754,8 @@ return (
       key={`${campus}-${buildingId}-selected-outer`}
       coordinates={coordinates}
       fillColor="transparent"
-      strokeColor="#000000"
-      strokeWidth={6}
+      strokeColor="#515351ff"
+      strokeWidth={5}
       tappable
       onPress={() =>
         handleBuildingPress(buildingId, campus, centerCoordinates)
@@ -784,13 +784,14 @@ return (
       <Marker
         key={`${campus}-${buildingId}-dest-pin`}
         coordinate={centerCoordinates}
-        anchor={{ x: 0.5, y: 1 }}
+        anchor={{ x: 0.5, y:0.5 }}
         zIndex={1000}
         onPress={() =>
           handleBuildingPress(buildingId, campus, centerCoordinates)
         }
         accessibilityLabel={`${name} destination`}
         accessibilityRole="button"
+        flat
       >
         <MaterialIcons name="place" size={26} color="#B03060" />
       </Marker>


### PR DESCRIPTION
Updated the building selection and destination visuals on the campus map for better clarity and consistency.

Changes made:

-Replaced the light pink selection outline that was not very visible on the map with a black outline for selected buildings.
-Removed the previous highlight layering to simplify the selection appearance.
-Added a Google-style destination pin to clearly indicate the destination building.
These changes fix issue #256 