### PR TITLE
feat(notifications): added notifications and preferences

### DIFF
--- a/frontend/conuwalks/app/(dev)/_layout.tsx
+++ b/frontend/conuwalks/app/(dev)/_layout.tsx
@@ -2,7 +2,6 @@ import { Stack, useRouter, useSegments } from "expo-router";
 import { useEffect, useState, useRef } from "react";
 import { View, ActivityIndicator } from "react-native";
 import { getTokens, isTokenValid } from "@/src/utils/tokenStorage";
-import UpcomingClassBanner from "@/src/components/UpcomingClassBanner";
 
 export default function DevLayout() {
   const [isAuthenticated, setIsAuthenticated] = useState<boolean | null>(null);
@@ -84,21 +83,6 @@ export default function DevLayout() {
         <Stack.Screen name="home" options={{ headerShown: false }} />
         <Stack.Screen name="login" options={{ headerShown: false }} />
       </Stack>
-
-      {segments[segments.length - 1] !== "login" && (
-        <View
-          style={{
-            position: "absolute",
-            top: 50,
-            left: 0,
-            right: 0,
-            zIndex: 20,
-          }}
-          pointerEvents="box-none"
-        >
-          <UpcomingClassBanner />
-        </View>
-      )}
     </View>
   );
 }

--- a/frontend/conuwalks/app/(dev)/home.tsx
+++ b/frontend/conuwalks/app/(dev)/home.tsx
@@ -9,6 +9,7 @@ import { useRouter } from "expo-router";
 import CampusMap from "@/src/components/CampusMap";
 import StatusGradient from "@/src/components/StatusGradient";
 import SegmentedToggle from "@/src/components/SegmentedToggle";
+import UpcomingClassBanner from "@/src/components/UpcomingClassBanner";
 import { clearTokens, getUserInfo } from "@/src/utils/tokenStorage";
 import { styles } from "@/src/styles/home";
 import { useDirections } from "@/src/context/DirectionsContext";
@@ -111,6 +112,20 @@ export default function DevHomeScreen() {
       </View>
 
       <StatusGradient />
+      {!isNavigationActive && (
+        <View
+          style={{
+            position: "absolute",
+            top: 50,
+            left: 0,
+            right: 0,
+            zIndex: 20,
+          }}
+          pointerEvents="box-none"
+        >
+          <UpcomingClassBanner onNavigateToClass={() => setSelectedView("map")} />
+        </View>
+      )}
       {!isNavigationActive && selectedView === "map" && (
         <SegmentedToggle campus={campus} setCampus={setCampus} />
       )}

--- a/frontend/conuwalks/src/_tests_/unit/UpcomingClassBanner.test.tsx
+++ b/frontend/conuwalks/src/_tests_/unit/UpcomingClassBanner.test.tsx
@@ -4,6 +4,8 @@ import { act } from "react";
 import { PanResponder } from "react-native";
 import UpcomingClassBanner from "../../components/UpcomingClassBanner";
 import { useGoogleCalendar } from "@/src/hooks/useGoogleCalendar";
+import { useDirections } from "@/src/context/DirectionsContext";
+import { useUserLocation } from "@/src/hooks/useUserLocation";
 import {
   getClassReminderLeadTime,
   getDismissedClassEventIds,
@@ -11,6 +13,12 @@ import {
 } from "@/src/utils/tokenStorage";
 
 jest.mock("@/src/hooks/useGoogleCalendar");
+jest.mock("@/src/context/DirectionsContext", () => ({
+  useDirections: jest.fn(),
+}));
+jest.mock("@/src/hooks/useUserLocation", () => ({
+  useUserLocation: jest.fn(),
+}));
 jest.mock("@expo/vector-icons/MaterialIcons", () => "MaterialIcons");
 jest.mock("@/src/utils/tokenStorage", () => ({
   getClassReminderLeadTime: jest.fn(),
@@ -27,9 +35,15 @@ jest.spyOn(PanResponder, "create").mockImplementation((config) => {
 });
 
 const mockUseGoogleCalendar = useGoogleCalendar as jest.Mock;
+const mockUseDirections = useDirections as jest.Mock;
+const mockUseUserLocation = useUserLocation as jest.Mock;
 const mockGetClassReminderLeadTime = getClassReminderLeadTime as jest.Mock;
 const mockGetDismissedClassEventIds = getDismissedClassEventIds as jest.Mock;
 const mockSaveDismissedClassEventIds = saveDismissedClassEventIds as jest.Mock;
+
+const mockSetStartPoint = jest.fn();
+const mockSetDestination = jest.fn();
+const mockSetShowDirections = jest.fn();
 
 const getFromNow = (minutes: number) => {
   const d = new Date();
@@ -69,6 +83,14 @@ describe("UpcomingClassBanner", () => {
     mockGetClassReminderLeadTime.mockResolvedValue(30);
     mockGetDismissedClassEventIds.mockResolvedValue([]);
     mockSaveDismissedClassEventIds.mockResolvedValue(true);
+    mockUseDirections.mockReturnValue({
+      setStartPoint: mockSetStartPoint,
+      setDestination: mockSetDestination,
+      setShowDirections: mockSetShowDirections,
+    });
+    mockUseUserLocation.mockReturnValue({
+      location: { latitude: 45.497, longitude: -73.579 },
+    });
   });
 
   it("renders nothing when there are no events", () => {
@@ -128,6 +150,56 @@ describe("UpcomingClassBanner", () => {
     render(<UpcomingClassBanner />);
     await waitFor(() => {
       expect(screen.getByTestId("banner-bell-icon")).toBeTruthy();
+    });
+  });
+
+  it("routes to in-app live navigation when Navigate is pressed", async () => {
+    buildBaseMock([
+      {
+        id: "nav-event",
+        summary: "COMP 346",
+        start: { dateTime: getFromNow(10) },
+        end: { dateTime: getFromNow(70) },
+        location: "H-820",
+      },
+    ]);
+
+    render(<UpcomingClassBanner />);
+
+    const navigateButton = await waitFor(() =>
+      screen.getByTestId("banner-navigate-button"),
+    );
+    fireEvent.press(navigateButton);
+
+    await waitFor(() => {
+      expect(mockSetStartPoint).toHaveBeenCalled();
+      expect(mockSetDestination).toHaveBeenCalled();
+      expect(mockSetShowDirections).toHaveBeenCalledWith(true);
+      expect(screen.queryByTestId("upcoming-class-banner")).toBeNull();
+    });
+  });
+
+  it("calls onNavigateToClass callback after setting directions", async () => {
+    const onNavigateToClass = jest.fn();
+    buildBaseMock([
+      {
+        id: "nav-event-callback",
+        summary: "COMP 346",
+        start: { dateTime: getFromNow(10) },
+        end: { dateTime: getFromNow(70) },
+        location: "H-820",
+      },
+    ]);
+
+    render(<UpcomingClassBanner onNavigateToClass={onNavigateToClass} />);
+
+    const navigateButton = await waitFor(() =>
+      screen.getByTestId("banner-navigate-button"),
+    );
+    fireEvent.press(navigateButton);
+
+    await waitFor(() => {
+      expect(onNavigateToClass).toHaveBeenCalled();
     });
   });
 
@@ -256,13 +328,14 @@ describe("UpcomingClassBanner", () => {
 
   it("keeps a dismissed class hidden after remount", async () => {
     mockGetClassReminderLeadTime.mockResolvedValue(30);
+    const firstEvent = createClassEvent("first", "CLASS 3:09", 9);
+    const secondEvent = createClassEvent("second", "CLASS 3:12", 12);
+    const firstDismissKey = `${firstEvent.id}::${firstEvent.start.dateTime}`;
+
     mockGetDismissedClassEventIds
       .mockResolvedValueOnce([])
-      .mockResolvedValueOnce(["first"]);
-    buildBaseMock([
-      createClassEvent("first", "CLASS 3:09", 9),
-      createClassEvent("second", "CLASS 3:12", 12),
-    ]);
+      .mockResolvedValueOnce([firstDismissKey]);
+    buildBaseMock([firstEvent, secondEvent]);
 
     const firstRender = render(<UpcomingClassBanner />);
 
@@ -274,7 +347,7 @@ describe("UpcomingClassBanner", () => {
 
     await waitFor(() => {
       expect(mockSaveDismissedClassEventIds).toHaveBeenCalledWith(
-        expect.arrayContaining(["first"]),
+        expect.arrayContaining([expect.stringContaining("first")]),
       );
       expect(screen.getByText(/Next Class: CLASS 3:12/i)).toBeTruthy();
     });
@@ -285,6 +358,29 @@ describe("UpcomingClassBanner", () => {
     await waitFor(() => {
       expect(screen.queryByText(/Next Class: CLASS 3:09/i)).toBeNull();
       expect(screen.getByText(/Next Class: CLASS 3:12/i)).toBeTruthy();
+    });
+  });
+
+  it("dismisses only a single occurrence when event id repeats at another time", async () => {
+    mockGetClassReminderLeadTime.mockResolvedValue(60);
+    mockGetDismissedClassEventIds.mockResolvedValue([]);
+
+    const repeatedId = "repeat-1";
+    buildBaseMock([
+      createClassEvent(repeatedId, "CLASS 6:20", 20),
+      createClassEvent(repeatedId, "CLASS 6:38", 38),
+    ]);
+
+    render(<UpcomingClassBanner />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Next Class: CLASS 6:20/i)).toBeTruthy();
+    });
+
+    fireEvent.press(screen.getByTestId("banner-close-button"));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Next Class: CLASS 6:38/i)).toBeTruthy();
     });
   });
 

--- a/frontend/conuwalks/src/components/UpcomingClassBanner.tsx
+++ b/frontend/conuwalks/src/components/UpcomingClassBanner.tsx
@@ -1,10 +1,24 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import { Animated, PanResponder, View, Text, TouchableOpacity } from "react-native";
+import {
+  Animated,
+  PanResponder,
+  View,
+  Text,
+  TouchableOpacity,
+} from "react-native";
 import MaterialIcons from "@expo/vector-icons/MaterialIcons";
 import { useGoogleCalendar } from "@/src/hooks/useGoogleCalendar";
 import { parseLocation } from "@/src/hooks/useBuildingEvents";
-import { SGWBuildingMetadata } from "@/src/data/metadata/SGW.BuildingMetaData";
-import { LoyolaBuildingMetadata } from "@/src/data/metadata/LOY.BuildingMetadata";
+import { useDirections } from "@/src/context/DirectionsContext";
+import { useUserLocation } from "@/src/hooks/useUserLocation";
+import {
+  SGWBuildingMetadata,
+  SGWBuildingSearchMetadata,
+} from "@/src/data/metadata/SGW.BuildingMetaData";
+import {
+  LoyolaBuildingMetadata,
+  LoyolaBuildingSearchMetadata,
+} from "@/src/data/metadata/LOY.BuildingMetadata";
 import {
   getClassReminderLeadTime,
   DEFAULT_CLASS_REMINDER_LEAD_TIME_MINUTES,
@@ -16,8 +30,19 @@ const BANNER_BG = "#FFD6DF";
 const BANNER_ACCENT = "#B03060";
 const DISMISS_THRESHOLD = -30; // px upward swipe needed to dismiss
 
-const UpcomingClassBanner: React.FC = () => {
+const buildDismissKey = (eventId: string, startStr: string | null): string =>
+  startStr ? `${eventId}::${startStr}` : eventId;
+
+interface UpcomingClassBannerProps {
+  onNavigateToClass?: () => void;
+}
+
+const UpcomingClassBanner: React.FC<UpcomingClassBannerProps> = ({
+  onNavigateToClass,
+}) => {
   const { events, fetchUpcomingEvents } = useGoogleCalendar();
+  const { location: userLocation } = useUserLocation();
+  const { setStartPoint, setDestination, setShowDirections } = useDirections();
   const [dismissedEventIds, setDismissedEventIds] = useState<string[]>([]);
   const dismissedEventIdsRef = useRef<string[]>([]);
   const [reminderLeadTimeMinutes, setReminderLeadTimeMinutes] = useState(
@@ -79,10 +104,11 @@ const UpcomingClassBanner: React.FC = () => {
     return events
       .filter((e) => {
         const startStr = e.start?.dateTime || e.start?.date;
+        const dismissKey = buildDismissKey(e.id, startStr || null);
         return (
           startStr &&
           new Date(startStr).getTime() > now &&
-          !dismissedEventIds.includes(e.id)
+          !dismissedEventIds.includes(dismissKey)
         );
       })
       .sort((a, b) => {
@@ -139,9 +165,11 @@ const UpcomingClassBanner: React.FC = () => {
   const dismissCurrentBanner = () => {
     if (nextEventIdRef.current) {
       const dismissedId = nextEventIdRef.current;
-      const nextIds = dismissedEventIdsRef.current.includes(dismissedId)
+      const dismissedStartStr = nextEvent?.start?.dateTime || nextEvent?.start?.date || null;
+      const dismissedKey = buildDismissKey(dismissedId, dismissedStartStr);
+      const nextIds = dismissedEventIdsRef.current.includes(dismissedKey)
         ? dismissedEventIdsRef.current
-        : [...dismissedEventIdsRef.current, dismissedId];
+        : [...dismissedEventIdsRef.current, dismissedKey];
 
       dismissedEventIdsRef.current = nextIds;
       setDismissedEventIds(nextIds);
@@ -190,10 +218,33 @@ const UpcomingClassBanner: React.FC = () => {
   const buildingMeta = buildingCode
     ? SGWBuildingMetadata[buildingCode] ?? LoyolaBuildingMetadata[buildingCode] ?? null
     : null;
+  const buildingCoordinates = buildingCode
+    ? SGWBuildingSearchMetadata[buildingCode]?.coordinates ??
+      LoyolaBuildingSearchMetadata[buildingCode]?.coordinates ??
+      null
+    : null;
 
   const locationLabel = buildingMeta && roomNumber
     ? `${buildingMeta.name} \u2013 Room ${roomNumber}`
     : nextEvent.location ?? null;
+
+  const handleNavigatePress = async () => {
+    if (!buildingCode || !buildingCoordinates) {
+      dismissCurrentBanner();
+      return;
+    }
+
+    const destinationName = buildingMeta?.name || buildingCode;
+
+    if (userLocation) {
+      setStartPoint("USER", userLocation, "My Location");
+    }
+
+    setDestination(buildingCode, buildingCoordinates, destinationName);
+    setShowDirections(true);
+    onNavigateToClass?.();
+    dismissCurrentBanner();
+  };
 
   return (
     <Animated.View
@@ -245,6 +296,32 @@ const UpcomingClassBanner: React.FC = () => {
         <Text style={{ fontSize: 13, color: BANNER_ACCENT, fontWeight: "500" }}>
           {`Starts at ${timeLabel}`}
         </Text>
+        <TouchableOpacity
+          onPress={handleNavigatePress}
+          accessibilityRole="button"
+          accessibilityLabel="Navigate to next class"
+          testID="banner-navigate-button"
+          style={{
+            marginTop: 8,
+            alignSelf: "flex-start",
+            backgroundColor: "rgba(176,48,96,0.14)",
+            borderWidth: 1,
+            borderColor: "rgba(176,48,96,0.28)",
+            borderRadius: 999,
+            paddingHorizontal: 10,
+            paddingVertical: 5,
+          }}
+        >
+          <Text
+            style={{
+              fontSize: 12,
+              fontWeight: "700",
+              color: BANNER_ACCENT,
+            }}
+          >
+            Navigate
+          </Text>
+        </TouchableOpacity>
       </View>
       <TouchableOpacity
         onPress={dismissCurrentBanner}

--- a/frontend/conuwalks/src/components/UserProfileContent.tsx
+++ b/frontend/conuwalks/src/components/UserProfileContent.tsx
@@ -1,13 +1,21 @@
 import React, { useEffect, useState } from "react";
-import { View, Text, StyleSheet, TouchableOpacity } from "react-native";
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  TextInput,
+} from "react-native";
 import MaterialIcons from "@expo/vector-icons/MaterialIcons";
 import { openNotificationSettings, openAppearanceSettings } from "@/src/utils/openSystemSettings";
 import {
   getClassReminderLeadTime,
   saveClassReminderLeadTime,
+  MAX_CLASS_REMINDER_LEAD_TIME_MINUTES,
+  MIN_CLASS_REMINDER_LEAD_TIME_MINUTES,
 } from "@/src/utils/tokenStorage";
 
-const REMINDER_OPTIONS_MINUTES = [0, 5, 10, 15, 30];
+const REMINDER_OPTIONS_MINUTES = [0, 5, 10, 15, 30, 45, 60];
 
 const ProfileSection = ({ title, children, mode }: any) => (
   <View style={styles.section}>
@@ -36,6 +44,7 @@ const ProfileSection = ({ title, children, mode }: any) => (
 const UserProfileContent = ({ userInfo, onSignOut, mode }: any) => {
   const textColor = mode === "dark" ? "#FFF" : "#333";
   const [reminderLeadTime, setReminderLeadTime] = useState<number>(10);
+  const [customReminderInput, setCustomReminderInput] = useState("");
 
   useEffect(() => {
     let mounted = true;
@@ -44,6 +53,9 @@ const UserProfileContent = ({ userInfo, onSignOut, mode }: any) => {
       const value = await getClassReminderLeadTime();
       if (mounted) {
         setReminderLeadTime(value);
+        if (!REMINDER_OPTIONS_MINUTES.includes(value)) {
+          setCustomReminderInput(String(value));
+        }
       }
     };
 
@@ -64,6 +76,13 @@ const UserProfileContent = ({ userInfo, onSignOut, mode }: any) => {
       setReminderLeadTime(fallback);
     }
   };
+
+  const parsedCustomReminder = Number(customReminderInput);
+  const isCustomReminderValid =
+    customReminderInput.trim().length > 0 &&
+    Number.isFinite(parsedCustomReminder) &&
+    parsedCustomReminder >= MIN_CLASS_REMINDER_LEAD_TIME_MINUTES &&
+    parsedCustomReminder <= MAX_CLASS_REMINDER_LEAD_TIME_MINUTES;
 
   return (
     <View style={styles.container}>
@@ -94,7 +113,7 @@ const UserProfileContent = ({ userInfo, onSignOut, mode }: any) => {
         </View>
 
         <View style={styles.optionWrap}>
-          {REMINDER_OPTIONS_MINUTES.map((minutes) => {
+          {[...REMINDER_OPTIONS_MINUTES, ...(REMINDER_OPTIONS_MINUTES.includes(reminderLeadTime) ? [] : [reminderLeadTime])].map((minutes) => {
             const selected = reminderLeadTime === minutes;
             const label = minutes === 0 ? "Off" : `${minutes}m`;
 
@@ -133,6 +152,48 @@ const UserProfileContent = ({ userInfo, onSignOut, mode }: any) => {
             );
           })}
         </View>
+
+        <View style={styles.customReminderRow}>
+          <TextInput
+            value={customReminderInput}
+            onChangeText={setCustomReminderInput}
+            keyboardType="number-pad"
+            placeholder="Custom minutes"
+            placeholderTextColor={mode === "dark" ? "#8B8B8B" : "#9A9A9A"}
+            style={[
+              styles.customReminderInput,
+              {
+                color: textColor,
+                borderColor:
+                  mode === "dark"
+                    ? "rgba(255,255,255,0.2)"
+                    : "rgba(0,0,0,0.15)",
+                backgroundColor:
+                  mode === "dark"
+                    ? "rgba(255,255,255,0.06)"
+                    : "rgba(0,0,0,0.03)",
+              },
+            ]}
+            accessibilityLabel="Custom class reminder minutes"
+          />
+          <TouchableOpacity
+            style={[
+              styles.applyButton,
+              { opacity: isCustomReminderValid ? 1 : 0.5 },
+            ]}
+            disabled={!isCustomReminderValid}
+            onPress={() => {
+              handleReminderChange(Math.round(parsedCustomReminder));
+            }}
+            accessibilityRole="button"
+            accessibilityLabel="Apply custom class reminder"
+          >
+            <Text style={styles.applyButtonText}>Apply</Text>
+          </TouchableOpacity>
+        </View>
+        <Text style={[styles.rangeText, { color: mode === "dark" ? "#AFAFAF" : "#666" }]}> 
+          {`Set any value from ${MIN_CLASS_REMINDER_LEAD_TIME_MINUTES} to ${MAX_CLASS_REMINDER_LEAD_TIME_MINUTES} minutes`}
+        </Text>
 
         <TouchableOpacity style={styles.row} onPress={() => openNotificationSettings()}>
           <MaterialIcons name="settings" size={22} color="#B03060" />
@@ -179,6 +240,38 @@ const styles = StyleSheet.create({
     borderRadius: 999,
     paddingHorizontal: 10,
     paddingVertical: 7,
+  },
+  customReminderRow: {
+    flexDirection: "row",
+    gap: 8,
+    paddingHorizontal: 14,
+    alignItems: "center",
+    paddingBottom: 8,
+  },
+  customReminderInput: {
+    flex: 1,
+    borderWidth: 1,
+    borderRadius: 10,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    fontSize: 14,
+    fontWeight: "500",
+  },
+  applyButton: {
+    backgroundColor: "#B03060",
+    borderRadius: 10,
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+  },
+  applyButtonText: {
+    color: "#FFF",
+    fontWeight: "700",
+    fontSize: 13,
+  },
+  rangeText: {
+    fontSize: 12,
+    paddingHorizontal: 14,
+    paddingBottom: 10,
   },
   signOutBtn: {
     flexDirection: "row",

--- a/frontend/conuwalks/src/utils/tokenStorage.ts
+++ b/frontend/conuwalks/src/utils/tokenStorage.ts
@@ -5,8 +5,25 @@ const TOKEN_KEY = "@auth_tokens";
 const USER_INFO_KEY = "@user_info";
 const CLASS_REMINDER_LEAD_TIME_KEY = "@class_reminder_lead_time";
 const DISMISSED_CLASS_EVENT_IDS_KEY = "@dismissed_class_event_ids";
-const VALID_REMINDER_MINUTES = [0, 5, 10, 15, 30] as const;
 export const DEFAULT_CLASS_REMINDER_LEAD_TIME_MINUTES = 10;
+export const MIN_CLASS_REMINDER_LEAD_TIME_MINUTES = 0;
+export const MAX_CLASS_REMINDER_LEAD_TIME_MINUTES = 180;
+
+const normalizeReminderMinutes = (value: unknown): number | null => {
+  const parsed = Number(value);
+
+  if (!Number.isFinite(parsed)) return null;
+
+  const rounded = Math.round(parsed);
+  if (
+    rounded < MIN_CLASS_REMINDER_LEAD_TIME_MINUTES ||
+    rounded > MAX_CLASS_REMINDER_LEAD_TIME_MINUTES
+  ) {
+    return null;
+  }
+
+  return rounded;
+};
 
 export interface AuthTokens {
   accessToken: string;
@@ -113,11 +130,15 @@ export const saveClassReminderLeadTime = async (
   minutes: number,
 ): Promise<boolean> => {
   try {
-    if (!VALID_REMINDER_MINUTES.includes(minutes as any)) {
+    const normalizedMinutes = normalizeReminderMinutes(minutes);
+    if (normalizedMinutes === null) {
       throw new Error(`Invalid reminder value: ${minutes}`);
     }
 
-    await AsyncStorage.setItem(CLASS_REMINDER_LEAD_TIME_KEY, String(minutes));
+    await AsyncStorage.setItem(
+      CLASS_REMINDER_LEAD_TIME_KEY,
+      String(normalizedMinutes),
+    );
     return true;
   } catch (error) {
     console.error("Error saving class reminder lead time:", error);
@@ -130,12 +151,12 @@ export const getClassReminderLeadTime = async (): Promise<number> => {
     const raw = await AsyncStorage.getItem(CLASS_REMINDER_LEAD_TIME_KEY);
     if (!raw) return DEFAULT_CLASS_REMINDER_LEAD_TIME_MINUTES;
 
-    const parsed = Number(raw);
-    if (!VALID_REMINDER_MINUTES.includes(parsed as any)) {
+    const normalized = normalizeReminderMinutes(raw);
+    if (normalized === null) {
       return DEFAULT_CLASS_REMINDER_LEAD_TIME_MINUTES;
     }
 
-    return parsed;
+    return normalized;
   } catch (error) {
     console.error("Error reading class reminder lead time:", error);
     return DEFAULT_CLASS_REMINDER_LEAD_TIME_MINUTES;


### PR DESCRIPTION
- Added `UpcomingClassBanner` component to show the next eligible class reminder.
- Added class reminder preference options in profile (`Off`, `5m`, `10m`, `15m`, `30m`).
- Added test for this new feature: npm test -- src/_tests_/unit/UpcomingClassBanner.test.tsx

Behavior
- Banner only shows classes within selected reminder window.
- Dismissing one class advances to the next eligible upcoming class.

<img width="333" height="100" alt="image" src="https://github.com/user-attachments/assets/10af215e-53e4-4c86-b52f-7558c491c91d" />

<img width="329" height="151" alt="image" src="https://github.com/user-attachments/assets/6679aa5d-5cb4-412f-8b9a-2ab9dd2326b7" />
