### PR TITLE
Stopping the night sync 

### DIFF
--- a/.github/workflows/nightly-sync.yml
+++ b/.github/workflows/nightly-sync.yml
@@ -1,9 +1,9 @@
 name: Nightly sync dev -> main (v0.x.0)
 
 on:
-  schedule:
+  # schedule:
     # 07:00 UTC is ~ 02:00 Montreal (EST)
-    - cron: "0 7 * * *"
+    # - cron: "0 7 * * *"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This pr is to stop the night sync workflow from running every night.