### PR TITLE
Added Longer Building Names on the Map, Increased the Size of the Directions and Indoor Map Buttons to Improve Visibility (+ Reduced the High Cognitive Complexity of Two Functions and Slightly Redesigned Parts of the Building Info Sheet's Header)

### DIFF
--- a/frontend/conuwalks/src/_tests_/ui/AdditionalInfoPopupHeader.test.tsx
+++ b/frontend/conuwalks/src/_tests_/ui/AdditionalInfoPopupHeader.test.tsx
@@ -153,13 +153,12 @@ describe("PopupHeader Component", () => {
     expect(screen.UNSAFE_queryByType("MetroIcon" as any)).toBeTruthy();
 
     // verify sf symbol is used for the standard icon
-    const sfSymbol = screen.UNSAFE_queryByType("SymbolView" as any);
-    expect(sfSymbol).toBeTruthy();
-    expect(sfSymbol.props.name).toBe("figure.roll");
+    const sfSymbol = screen.UNSAFE_queryAllByType("SymbolView" as any);
+    expect(sfSymbol.some(symbol => symbol.props.name === "figure.roll")).toBeTruthy();
 
     // materialicons should not be rendered on ios (unless it's the directions arrow, which is hardcoded)
     const materialIcons = screen.UNSAFE_queryAllByType("MaterialIcons" as any);
-    expect(materialIcons.some((icon) => icon.props.name === "accessible")).toBe(
+    expect(materialIcons.some(icon => icon.props.name === "accessible-forward")).toBe(
       false,
     );
   });

--- a/frontend/conuwalks/src/components/AdditionalInfoPopupHeader.tsx
+++ b/frontend/conuwalks/src/components/AdditionalInfoPopupHeader.tsx
@@ -1,5 +1,5 @@
-import React, { memo } from "react";
-import { View, Text, TouchableOpacity, TouchableWithoutFeedback, Platform, AccessibilityActionEvent } from "react-native";
+import React, { useState, memo } from "react";
+import { View, Text, TouchableOpacity, TouchableWithoutFeedback, Platform, AccessibilityActionEvent, LayoutChangeEvent } from "react-native";
 
 import MaterialIcons from "@expo/vector-icons/MaterialIcons";
 import { SymbolView } from "expo-symbols";
@@ -26,16 +26,17 @@ interface AdditionalInfoPopupHeaderProps {
 // helper logic
 const renderAccessibilityIcon = (icon: AccessibilityIconDef, mode: "light" | "dark") => {
   const iconColor = themedStyles.subtext(mode).color;
+  const iconSize = 25;
 
   if (icon.key === "metro") {
-    return <MetroIcon width={25} height={25} color={iconColor} />;
+    return <MetroIcon width={iconSize} height={iconSize} color={iconColor} />;
   }
 
   if (Platform.OS === "ios") {
-    return <SymbolView name={icon.sf} size={25} weight="heavy" tintColor={iconColor} />;
+    return <SymbolView name={icon.sf} size={iconSize} weight="heavy" tintColor={iconColor} />;
   }
 
-  return <PlatformIcon materialName={icon.material} iosName={icon.sf} size={25} color={iconColor} weight="heavy" />;
+  return <PlatformIcon materialName={icon.material} iosName={icon.sf} size={iconSize} color={iconColor} weight="heavy" />;
 };
 
 const AdditionalInfoPopupHeader: React.FC<AdditionalInfoPopupHeaderProps> = ({
@@ -51,33 +52,69 @@ const AdditionalInfoPopupHeader: React.FC<AdditionalInfoPopupHeaderProps> = ({
   onToggleHeight,
   onDragHandleAccessibilityAction,
 }) => {
-  const campusPink = "#B03060";
   const isDark = mode === "dark";
+
+  const [sidePadding, setSidePadding] = useState(80);
+  const adjustTitleWidth = (event: LayoutChangeEvent) => {
+    const { width } = event.nativeEvent.layout;
+    setSidePadding(width + 1);
+    handleRightHeight(event);
+  };
+
+  const [leftHeight, setLeftHeight] = useState(10);
+  const handleLeftHeight = (event: LayoutChangeEvent) => {
+    const { height } = event.nativeEvent.layout;
+    setLeftHeight(height);
+  }
+  const [centerHeight, setCenterHeight] = useState(10);
+  const handleCenterHeight = (event: LayoutChangeEvent) => {
+    const { height } = event.nativeEvent.layout;
+    setCenterHeight(height);
+  }
+  const [rightHeight, setRightHeight] = useState(10);
+  const handleRightHeight = (event: LayoutChangeEvent) => {
+    const { height } = event.nativeEvent.layout;
+    setRightHeight(height);
+  }
 
   return (
     <>
       <BottomSheetDragHandle isDark={isDark} onToggleHeight={onToggleHeight} onAccessibilityAction={onDragHandleAccessibilityAction} />
 
       <TouchableWithoutFeedback onPress={onToggleHeight}>
-        <View style={styles.iosHeader}>
-          <TouchableOpacity
-            onPress={onDismiss}
-            style={[styles.closeButton, Platform.OS === "android" && { width: "auto", padding: 4 }]}
-            hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
-            accessible={true}
-            accessibilityLabel="Close"
-            accessibilityRole="button"
-          >
-            {Platform.OS === "android" ? (
-              <MaterialIcons name="close" size={24} color={themedStyles.text(mode).color} />
-            ) : (
-              <View style={[styles.closeButtonCircle, themedStyles.closeButton(mode)]}>
-                <Text style={[styles.closeButtonText, themedStyles.text(mode)]}>✕</Text>
-              </View>
-            )}
-          </TouchableOpacity>
+        <View style={[styles.iosHeader, {height: Math.max(leftHeight, centerHeight, rightHeight)}]}>
+          <View style={styles.leftHeaderActions} onLayout={handleLeftHeight}>
+            <TouchableOpacity
+              onPress={() => {onDismiss()}}
+              style={[styles.closeButton, Platform.OS === "android" && { width: "auto", padding: 4 }]}
+              hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+              accessible={true}
+              accessibilityLabel="Close"
+              accessibilityRole="button"
+            >
+              {Platform.OS === "android" ? (
+                <MaterialIcons name="close" size={24} color={themedStyles.text(mode).color} />
+              ) : (
+                <View style={[styles.closeButtonCircle, themedStyles.closeButton(mode)]}>
+                  <Text style={[styles.closeButtonText, themedStyles.text(mode)]}>✕</Text>
+                </View>
+              )}
+            </TouchableOpacity>
 
-          <View style={styles.headerTextContainer}>
+            {showOpenIndoorButton && onOpenIndoorPress && (
+              <TouchableOpacity
+                onPress={onOpenIndoorPress}
+                style={[styles.openIndoorHeaderButton, themedStyles.openIndoorHeaderButton(mode)]}
+                accessibilityRole="button"
+                accessibilityLabel="Open indoor map"
+              >
+                <PlatformIcon materialName="map" iosName="map" size={25} color="black"/>
+                <Text style={[styles.openIndoorHeaderButtonText, themedStyles.openIndoorHeaderButtonText(mode)]}>Indoor</Text>
+              </TouchableOpacity>
+            )}
+          </View>
+
+          <View style={[styles.headerTextContainer, {paddingHorizontal:sidePadding}]} onLayout={handleCenterHeight}>
             <Text style={[styles.buildingName, themedStyles.text(mode)]} accessibilityRole="header">
               {buildingInfo?.name || "Building"}
             </Text>
@@ -88,28 +125,15 @@ const AdditionalInfoPopupHeader: React.FC<AdditionalInfoPopupHeaderProps> = ({
             </View>
           </View>
 
-          <View style={styles.rightHeaderActions}>
-            {showOpenIndoorButton && onOpenIndoorPress && (
-              <TouchableOpacity
-                onPress={onOpenIndoorPress}
-                style={[styles.openIndoorHeaderButton, themedStyles.openIndoorHeaderButton(mode)]}
-                accessibilityRole="button"
-                accessibilityLabel="Open indoor map"
-                hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
-              >
-                <Text style={[styles.openIndoorHeaderButtonText, themedStyles.openIndoorHeaderButtonText(mode)]}>Indoor Map↗</Text>
-              </TouchableOpacity>
-            )}
-
+          <View style={styles.rightHeaderActions} onLayout={adjustTitleWidth}>
             <TouchableOpacity
               onPress={onDirectionsPress}
               style={styles.directionsButton}
               accessibilityRole="button"
               accessibilityLabel={`Directions, ${directionsEtaLabel || "--"}`}
-              hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
             >
               <View style={styles.directionsArrowCircle}>
-                <MaterialIcons name="subdirectory-arrow-right" size={12} color={campusPink} />
+                <PlatformIcon materialName="directions" iosName="arrow.trianglehead.turn.up.right.circle.fill" size={33} color="#FFFFFF" />
               </View>
               <Text style={styles.directionsEtaText}>{directionsEtaLabel || "--"}</Text>
             </TouchableOpacity>

--- a/frontend/conuwalks/src/components/CampusMap.tsx
+++ b/frontend/conuwalks/src/components/CampusMap.tsx
@@ -208,7 +208,7 @@ const CampusMap: React.FC<CampusMapProps> = ({
   // Get user's location with permission handling
   const { location: userLocation, error: locationError, loading: locationLoading } = useUserLocation();
 
-  const INITIAL_DELTA = 0.008;
+  const INITIAL_DELTA = 0.004;
 
   // State to control building search popup
   const [buildingSearchVisible, setBuildingSearchVisible] = useState(false);
@@ -866,30 +866,36 @@ const CampusMap: React.FC<CampusMapProps> = ({
 
     let targetBuildingId = userLocationBuildingId;
 
-    if (!targetBuildingId && startBuildingId && startBuildingId !== "USER" && navigationStepIndex === 0) {
+    if (
+      !targetBuildingId
+      && ![null, "USER"].includes(startBuildingId)
+      && navigationStepIndex === 0
+    ) {
       targetBuildingId = startBuildingId;
     }
 
     // proximity fallback
-    if (!targetBuildingId && destinationBuildingId && destinationCenter && userLocation) {
-      const dist = distanceMetersBetween(userLocation, destinationCenter);
-      if (dist <= 65) {
-        targetBuildingId = destinationBuildingId;
-      }
+    if (
+      !targetBuildingId
+      && destinationBuildingId
+      && destinationCenter
+      && userLocation
+      && 65 >= distanceMetersBetween(userLocation, destinationCenter)
+    ) {
+      targetBuildingId = destinationBuildingId;
     }
 
-    if (targetBuildingId && INDOOR_DATA[targetBuildingId]) {
-      if (indoorBuildingId !== targetBuildingId && manuallyExitedBuildingId !== targetBuildingId) {
-        setIndoorBuildingId(targetBuildingId);
-      }
-    } else if (!targetBuildingId) {
-      if (manuallyExitedBuildingId !== null) {
-        setManuallyExitedBuildingId(null);
-      }
-
-      if (indoorBuildingId && indoorBuildingId !== destinationBuildingId) {
+    if (!targetBuildingId) {
+      setManuallyExitedBuildingId(null);
+      if (indoorBuildingId !== destinationBuildingId) {
         setIndoorBuildingId(null);
       }
+    } else if (
+      targetBuildingId
+      && INDOOR_DATA[targetBuildingId]
+      && ![indoorBuildingId, manuallyExitedBuildingId].includes(targetBuildingId)
+    ) {
+      setIndoorBuildingId(targetBuildingId);
     }
   }, [
     userLocation,

--- a/frontend/conuwalks/src/components/CampusMap.tsx
+++ b/frontend/conuwalks/src/components/CampusMap.tsx
@@ -128,7 +128,7 @@ const BuildingGroup = React.memo(
         ? themeColor + "C8"
         : dimOthers
           ? themeColor + "55"
-          : themeColor + "90";
+          : themeColor + "B0";
 
     return (
       <React.Fragment>

--- a/frontend/conuwalks/src/components/RoutePolyline.tsx
+++ b/frontend/conuwalks/src/components/RoutePolyline.tsx
@@ -112,7 +112,7 @@ const injectShuttleRoute = async (
   
   const hMatch = /(\d{1,5})\s{0,5}h/.exec(durStr);
   const mMatch = /(\d{1,5})\s{0,5}min/.exec(durStr);
-  const publicMins = Number.parseInt(hMatch?.[1] ?? "0") + Number.parseInt(mMatch?.[1] ?? "0");
+  const publicMins = Number.parseInt(hMatch?.[1] ?? "0")*60 + Number.parseInt(mMatch?.[1] ?? "0");
 
   const shuttleDepMs = new Date(shuttleRoute.departureDate).getTime();
   const targetTimeMs = routingTime.getTime();

--- a/frontend/conuwalks/src/components/RoutePolyline.tsx
+++ b/frontend/conuwalks/src/components/RoutePolyline.tsx
@@ -102,30 +102,29 @@ const injectShuttleRoute = async (
   timeMode: "leave" | "arrive",
 ) => {
   const shuttleRoute = await getShuttleRouteIfApplicable(effectiveStartLocation, destinationCoords, routingTime, timeMode);
-
   if (!shuttleRoute) return fetchedRoutes;
 
-  let showShuttle = true;
-  const bestPublicRoute = fetchedRoutes[0];
+  const durStr = fetchedRoutes[0]?.duration;
+  if (!durStr) {
+    fetchedRoutes.unshift(shuttleRoute);
+    return fetchedRoutes;
+  }
+  
+  const hMatch = /(\d{1,5})\s{0,5}h/.exec(durStr);
+  const mMatch = /(\d{1,5})\s{0,5}min/.exec(durStr);
+  const publicMins = Number.parseInt(hMatch?.[1] ?? "0") + Number.parseInt(mMatch?.[1] ?? "0");
 
-  if (bestPublicRoute?.duration) {
-    const durStr = bestPublicRoute.duration;
-    const hMatch = /(\d{1,5})\s{0,5}h/.exec(durStr);
-    const mMatch = /(\d{1,5})\s{0,5}min/.exec(durStr);
-    const publicMins = (hMatch ? parseInt(hMatch[1], 10) * 60 : 0) + (mMatch ? parseInt(mMatch[1], 10) : 0);
+  const shuttleDepMs = new Date(shuttleRoute.departureDate).getTime();
+  const targetTimeMs = routingTime.getTime();
 
-    const shuttleDepMs = new Date(shuttleRoute.departureDate).getTime();
-    const targetTimeMs = routingTime.getTime();
-
-    if (timeMode === "leave") {
-      if ((shuttleDepMs - targetTimeMs) / 60000 >= publicMins) showShuttle = false;
-    } else {
-      const publicDepMs = targetTimeMs - publicMins * 60000;
-      if ((publicDepMs - shuttleDepMs) / 60000 >= 45) showShuttle = false;
-    }
+  if (!(
+    timeMode === "leave"
+    && (shuttleDepMs - targetTimeMs) / 60000 >= publicMins
+    || (targetTimeMs - publicMins * 60000 - shuttleDepMs) / 60000 >= 45
+  )) {
+    fetchedRoutes.unshift(shuttleRoute);
   }
 
-  if (showShuttle) fetchedRoutes.unshift(shuttleRoute);
   return fetchedRoutes;
 };
 

--- a/frontend/conuwalks/src/components/campusLabels.tsx
+++ b/frontend/conuwalks/src/components/campusLabels.tsx
@@ -34,8 +34,9 @@ const CampusLabels: React.FC<Props> = ({
   return (
     <>
       {data.features.map((feature) => {
-        const { id, centroid } = feature.properties;
+        const { id, name, centroid } = feature.properties;
         if (!centroid) return null;
+        let label = fontSize > 25 && Platform.OS === "ios" ? name?.replaceAll(" ", `\n`) : id;
 
         return (
           <Marker
@@ -57,16 +58,14 @@ const CampusLabels: React.FC<Props> = ({
                   fontSize: fontSize,
                   fontWeight: "bold",
                   color: "#00000033",
+                  textAlign: "center"
                 }}
                 allowFontScaling={false}
                 importantForAccessibility="no"
                 accessible={false}
               >
-                {id}
+                {label}
               </Text>
-              {Platform.OS === "android" && (
-                <Text style={{ width: 1, height: 1, opacity: 0 }}> </Text>
-              )}
             </View>
           </Marker>
         );

--- a/frontend/conuwalks/src/data/BuildingLabels.ts
+++ b/frontend/conuwalks/src/data/BuildingLabels.ts
@@ -10,6 +10,7 @@ export type PolygonCoordinates = Coordinates[][];
 
 export interface FeatureProperties {
   id: string;
+  name: string;
   centroid?: LatLng;
 }
 
@@ -68,7 +69,7 @@ export function attachCentroids(
 export const getLabelFontSize = (delta: number) => {
   const zoomFactor = 0.004 / delta;
   const size = 25 * zoomFactor;
-  return Math.min(22, size);
+  return Math.min(22 + zoomFactor, size);
 };
 
 // ------------------------

--- a/frontend/conuwalks/src/data/campus/LOY.geojson.ts
+++ b/frontend/conuwalks/src/data/campus/LOY.geojson.ts
@@ -4,7 +4,7 @@
     {
       "type": "Feature",
 
-      "properties": { "id": "VL" },
+      "properties": { "id": "VL", "name": "Vanier Library" },
       "geometry": {
         "type": "Polygon",
         "coordinates": [[
@@ -42,7 +42,7 @@
     {
       "type": "Feature",
 
-      "properties": { "id": "SP" },
+      "properties": { "id": "SP", "name": "Renaud Science Complex" },
       "geometry": {
         "type": "Polygon",
        "coordinates": [[
@@ -92,7 +92,7 @@
     {
       "type": "Feature",
 
-      "properties": { "id": "CJ" },
+      "properties": { "id": "CJ", "name": "Communication and Journalism" },
       "geometry": {
         "type": "Polygon",
         "coordinates": [
@@ -138,7 +138,7 @@
     {
       "type": "Feature",
 
-      "properties": { "id": "CC" },
+      "properties": { "id": "CC", "name": "Central" },
       "geometry": {
         "type": "Polygon",
        "coordinates": [[
@@ -156,7 +156,7 @@
     {
       "type": "Feature",
 
-      "properties": { "id": "AD" },
+      "properties": { "id": "AD", "name": "Administration" },
       "geometry": {
         "type": "Polygon",
         "coordinates": [[
@@ -198,7 +198,7 @@
     {
       "type": "Feature",
 
-      "properties": { "id": "FC" },
+      "properties": { "id": "FC", "name": "FC Smith" },
       "geometry": {
         "type": "Polygon",
        "coordinates": [[
@@ -242,7 +242,7 @@
     {
       "type": "Feature",
 
-      "properties": { "id": "HU" },
+      "properties": { "id": "HU", "name": "Applied Science Hub" },
       "geometry": {
         "type": "Polygon",
         "coordinates": [[

--- a/frontend/conuwalks/src/data/campus/SGW.geojson.ts
+++ b/frontend/conuwalks/src/data/campus/SGW.geojson.ts
@@ -3,7 +3,7 @@ const SGW =  {
   "features": [
     {
       "type": "Feature",
-      "properties": { "id": "H" },
+      "properties": { "id": "H", "name": "Hall" },
       "geometry": {
         "type": "Polygon",
         "coordinates": [[
@@ -20,7 +20,7 @@ const SGW =  {
     },
     {
       "type": "Feature",
-      "properties": { "id": "LB" },
+      "properties": { "id": "LB", "name": "McConnell (Webster Library)" },
       "geometry": {
         "type": "Polygon",
         "coordinates":[[
@@ -40,7 +40,7 @@ const SGW =  {
     },
     {
       "type": "Feature",
-      "properties": { "id": "LS" },
+      "properties": { "id": "LS", "name": "Learning Square" },
       "geometry": {
         "type": "Polygon",
         "coordinates": [[
@@ -57,7 +57,7 @@ const SGW =  {
     },
     {
       "type": "Feature",
-      "properties": { "id": "EV"},
+      "properties": { "id": "EV", "name": "Engineering and Visual Arts" },
       "geometry": {
         "type": "Polygon",
     "coordinates":[[
@@ -74,7 +74,7 @@ const SGW =  {
     },
     {
       "type": "Feature",
-      "properties": { "id": "MB" },
+      "properties": { "id": "MB", "name": "Molson" },
       "geometry": {
         "type": "Polygon",
         "coordinates":[
@@ -93,7 +93,7 @@ const SGW =  {
     },
     {
       "type": "Feature",
-      "properties": { "id": "FB"},
+      "properties": { "id": "FB", "name": "Faubourg Tower" },
       "geometry": {
         "type": "Polygon",
         "coordinates":[[
@@ -107,7 +107,7 @@ const SGW =  {
     },
     {
       "type": "Feature",
-      "properties": { "id": "FG"},
+      "properties": { "id": "FG", "name": "Faubourg Ste-Caherine" },
       "geometry": {
         "type": "Polygon",
         "coordinates":[[
@@ -125,7 +125,7 @@ const SGW =  {
     },
     {
       "type": "Feature",
-      "properties": { "id": "CL"},
+      "properties": { "id": "CL", "name": "CL Annex" },
       "geometry": {
         "type": "Polygon",
        "coordinates":[[
@@ -140,7 +140,7 @@ const SGW =  {
     },
     {
       "type": "Feature",
-      "properties": { "id": "GM"},
+      "properties": { "id": "GM", "name": "Guy-De Maisonneuve" },
       "geometry": {
         "type": "Polygon",
  "coordinates": [[
@@ -155,7 +155,7 @@ const SGW =  {
     },
     {
       "type": "Feature",
-      "properties": { "id": "ER"},
+      "properties": { "id": "ER", "name": "ER Building" },
       "geometry": {
         "type": "Polygon",
         "coordinates":[[

--- a/frontend/conuwalks/src/hooks/useBuildingData.ts
+++ b/frontend/conuwalks/src/hooks/useBuildingData.ts
@@ -70,7 +70,7 @@ export const useBuildingData = (buildingId: string, campus: "SGW" | "LOY") => {
       icons.push({
         key: "wheelchair",
         sf: "figure.roll",
-        material: "accessible",
+        material: "accessible-forward",
         label: "First Floor is Wheelchair Accessible",
       });
     }

--- a/frontend/conuwalks/src/indoors/types/Building.ts
+++ b/frontend/conuwalks/src/indoors/types/Building.ts
@@ -16,6 +16,6 @@ export interface BuildingMetadata {
 export interface AccessibilityIconDef {
   key: string;
   sf: SFSymbol;
-  material: "elevator" | "accessible" | "subway";
+  material: "elevator" | "accessible-forward" | "subway";
   label: string;
 }

--- a/frontend/conuwalks/src/styles/additionalInfoPopup.ts
+++ b/frontend/conuwalks/src/styles/additionalInfoPopup.ts
@@ -30,20 +30,19 @@ const additionalInfoPopupStyles = StyleSheet.create({
   },
   iosHeader: {
     flexDirection: "row",
-    alignItems: "center",
+    alignItems: "flex-start",
     justifyContent: "center",
     position: "relative",
     paddingHorizontal: 20,
     width: "100%",
     backgroundColor: "transparent",
-    minHeight: 100, // Reduced from 136
-    paddingTop: 8, // Added padding
+    paddingTop: 8,
+    marginBottom: 10
   },
   headerTextContainer: {
-    flex: 1, // Changed from absolute positioning
+    position:"absolute",
     alignItems: "center",
     justifyContent: "center",
-    paddingHorizontal: 110, // Added padding instead of absolute positioning
     width: "100%",
   },
   buildingName: {
@@ -54,8 +53,6 @@ const additionalInfoPopupStyles = StyleSheet.create({
     marginBottom: 4,
     flexWrap: "wrap",
     flexShrink: 0,
-    width: "100%",
-    maxWidth: "100%",
     textAlignVertical: "center",
     alignSelf: "stretch",
   },
@@ -94,17 +91,26 @@ const additionalInfoPopupStyles = StyleSheet.create({
   accessibilityIcon: {
     fontSize: 22,
   },
+  leftHeaderActions: {
+    flexDirection: "column",
+    position:"absolute",
+    gap: Platform.OS === "ios" ? 5 : 0,
+    left:20,
+    top:10,
+    alignItems:"flex-start",
+    flex:1
+  },
   closeButton: {
     width: 44,
     height: 44,
-    justifyContent: "center",
-    alignItems: "center",
-    position: "absolute",
+    justifyContent: "flex-start",
+    alignItems: "flex-start",
     left: 20,
     top: 0,
     padding: 4,
     zIndex: 10,
-    marginTop: -5,
+    marginTop: -10,
+    marginLeft: -20
   },
   closeButtonText: {
     fontSize: 24,
@@ -128,9 +134,9 @@ const additionalInfoPopupStyles = StyleSheet.create({
 rightHeaderActions: {
   position: "absolute",
   right: 20,
-  top: 4,
   alignItems: "flex-end",
   justifyContent: "flex-start",
+  flex:1,
   gap: 8,
 },
   directionsButton: {
@@ -138,24 +144,22 @@ rightHeaderActions: {
     alignItems: "center",
     borderRadius: 999,
     backgroundColor: "#B03060",
-    paddingVertical: 5,
-    paddingHorizontal: 4,
-    gap: 6,
+    gap: 0
   },
   directionsArrowCircle: {
-    width: 18,
-    height: 18,
-    borderRadius: 9,
-    backgroundColor: "#FFFFFF",
+    width: 40,
+    height: 40,
+    borderRadius: 40,
+    backgroundColor: "transparent",
     alignItems: "center",
     justifyContent: "center",
   },
   directionsEtaText: {
     color: "#FFFFFF",
     fontWeight: "700" as const,
-    fontSize: 13,
+    fontSize: 15,
     lineHeight: 15,
-    paddingRight: 7,
+    paddingRight: 10,
   },
   rightAccessibilityRow: {
     marginTop: 2,
@@ -236,14 +240,15 @@ openIndoorHeaderButton: {
   justifyContent: "center",
   borderWidth: 1,
   borderRadius: 999,
-  paddingVertical: Platform.OS === "android" ? 7 : 6,
+  paddingVertical: 7,
   paddingHorizontal: 8,
   minHeight: 30,
+  gap: 5
 },
 
 openIndoorHeaderButtonText: {
   fontWeight: "600" as const,
-  fontSize: 13,
+  fontSize: 15,
   fontFamily: Platform.OS === "ios" ? "System" : "Roboto",
 },
   // Android styles


### PR DESCRIPTION
Unfortunately, the longer building names only apply to iOS: a major Google Maps (React Native Maps) bug crops overlayed text when longer than approximately two characters (iOS is immune thanks to Apple Maps). There doesn't appear to be a way around it.
The building names on the map were made longer and the directions and indoor map buttons were made larger to answer the feedback received as part of the usability testing.